### PR TITLE
Fixed bill decimal rounding

### DIFF
--- a/api/src/main/java/org/openmrs/module/openhmis/cashier/api/impl/CashierOptionsServiceGpImpl.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/cashier/api/impl/CashierOptionsServiceGpImpl.java
@@ -72,7 +72,7 @@ public class CashierOptionsServiceGpImpl implements ICashierOptionsService {
 
 				String roundToNearestProperty = adminService.getGlobalProperty(ModuleSettings.ROUND_TO_NEAREST_PROPERTY);
 				if (StringUtils.isNotEmpty(roundToNearestProperty)) {
-					options.setRoundToNearest(new BigDecimal(roundToNearestProperty));
+					options.setRoundToNearest(new Integer(roundToNearestProperty));
 
 					String roundingItemId = adminService.getGlobalProperty(ModuleSettings.ROUNDING_ITEM_ID);
 					if (StringUtils.isNotEmpty(roundingItemId)) {
@@ -114,7 +114,7 @@ public class CashierOptionsServiceGpImpl implements ICashierOptionsService {
 
 	private void setRoundingOptionsForEmptyUuid(CashierOptions options) {
 		options.setRoundingMode(CashierOptions.RoundingMode.MID);
-		options.setRoundToNearest(BigDecimal.ZERO);
+		options.setRoundToNearest(0);
 	}
 
 	private void setTimesheetOptions(CashierOptions options) {

--- a/api/src/main/java/org/openmrs/module/openhmis/cashier/api/model/CashierOptions.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/cashier/api/model/CashierOptions.java
@@ -21,8 +21,7 @@ import java.math.BigDecimal;
 public class CashierOptions {
 	public static final long serialVersionUID = 0L;
 
-	private static final BigDecimal DEFAULT_NO_ROUNDING = BigDecimal.ZERO;
-	private BigDecimal roundToNearest = DEFAULT_NO_ROUNDING;
+	private Integer roundToNearest = 0;
 	private RoundingMode roundingMode = RoundingMode.MID;
 	private String roundingItemUuid;
 	private int defaultReceiptReportId;
@@ -37,11 +36,11 @@ public class CashierOptions {
 	}
 
 	// Getters & setters
-	public BigDecimal getRoundToNearest() {
+	public Integer getRoundToNearest() {
 		return roundToNearest;
 	}
 
-	public void setRoundToNearest(BigDecimal roundToNearest) {
+	public void setRoundToNearest(Integer roundToNearest) {
 		this.roundToNearest = roundToNearest;
 	}
 

--- a/api/src/main/java/org/openmrs/module/openhmis/cashier/api/util/RoundingUtil.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/cashier/api/util/RoundingUtil.java
@@ -14,6 +14,8 @@
 package org.openmrs.module.openhmis.cashier.api.util;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -21,6 +23,7 @@ import org.openmrs.GlobalProperty;
 import org.openmrs.api.APIException;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
+import org.openmrs.logic.op.In;
 import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.module.openhmis.cashier.ModuleSettings;
 import org.openmrs.module.openhmis.cashier.api.ICashierOptionsService;
@@ -39,22 +42,19 @@ import org.openmrs.module.openhmis.inventory.api.model.ItemPrice;
 public class RoundingUtil {
 	protected RoundingUtil() {}
 
-	public static BigDecimal round(BigDecimal value, BigDecimal nearest, CashierOptions.RoundingMode mode) {
-		if (nearest.equals(BigDecimal.ZERO)) {
+	public static BigDecimal round(BigDecimal value, Integer nearest, CashierOptions.RoundingMode mode) {
+		if (nearest == null || nearest.equals(0)) {
 			return value;
 		}
-		BigDecimal factor = BigDecimal.ONE.divide(nearest);
-		int scale = nearest.scale();
+
+		double valueD = value.doubleValue();
 		switch (mode) {
 			case FLOOR:
-				return value.multiply(factor).setScale(value.scale(), BigDecimal.ROUND_FLOOR).divide(factor)
-				        .setScale(scale, BigDecimal.ROUND_FLOOR);
+				return new BigDecimal(nearest * (Math.floor(Math.abs(valueD / nearest))));
 			case CEILING:
-				return value.multiply(factor).setScale(value.scale(), BigDecimal.ROUND_CEILING).divide(factor)
-				        .setScale(scale, BigDecimal.ROUND_CEILING);
+				return new BigDecimal(nearest * (Math.ceil(Math.abs(valueD / nearest))));
 			default:
-				return value.multiply(factor).setScale(value.scale(), BigDecimal.ROUND_HALF_UP).divide(factor)
-				        .setScale(scale, BigDecimal.ROUND_HALF_UP);
+				return new BigDecimal(nearest * (Math.round(valueD / nearest)));
 		}
 	}
 
@@ -109,6 +109,9 @@ public class RoundingUtil {
 	 * @param bill
 	 * @should handle a rounding line item (add/update/delete with the appropriate value)
 	 * @should not modify a bill that needs no rounding
+	 * @should round bills with a non zero amount correctly for MID
+	 * @should round bills with a non zero amount correctly for CEILING
+	 * @should round bills with a non zero amount correctly for FLOOR
 	 */
 	public static void handleRoundingLineItem(Bill bill) {
 		ICashierOptionsService cashOptService = Context.getService(ICashierOptionsService.class);

--- a/api/src/main/java/org/openmrs/module/openhmis/cashier/api/util/RoundingUtil.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/cashier/api/util/RoundingUtil.java
@@ -53,8 +53,10 @@ public class RoundingUtil {
 				return new BigDecimal(nearest * (Math.floor(Math.abs(valueD / nearest))));
 			case CEILING:
 				return new BigDecimal(nearest * (Math.ceil(Math.abs(valueD / nearest))));
-			default:
+			case MID:
 				return new BigDecimal(nearest * (Math.round(valueD / nearest)));
+			default:
+				return value;
 		}
 	}
 

--- a/api/src/test/java/org/openmrs/module/openhmis/cashier/api/ICashierOptionsServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openhmis/cashier/api/ICashierOptionsServiceTest.java
@@ -46,7 +46,7 @@ public class ICashierOptionsServiceTest extends BaseModuleContextSensitiveTest {
 		Assert.assertEquals("4028814B399565AA01399681B1B5000E", options.getRoundingItemUuid());
 		Assert.assertEquals(3, options.getDefaultReceiptReportId());
 		Assert.assertEquals(CashierOptions.RoundingMode.MID, options.getRoundingMode());
-		Assert.assertTrue(new BigDecimal(5).equals(options.getRoundToNearest()));
+		Assert.assertEquals(5, (int)options.getRoundToNearest());
 		Assert.assertEquals(true, options.isTimesheetRequired());
 	}
 

--- a/api/src/test/java/org/openmrs/module/openhmis/cashier/api/impl/CashierOptionsServiceGpImplTest.java
+++ b/api/src/test/java/org/openmrs/module/openhmis/cashier/api/impl/CashierOptionsServiceGpImplTest.java
@@ -77,7 +77,7 @@ public class CashierOptionsServiceGpImplTest {
 		Assert.assertNotNull(options);
 		Assert.assertEquals(1, options.getDefaultReceiptReportId());
 		Assert.assertEquals(CashierOptions.RoundingMode.MID, options.getRoundingMode());
-		Assert.assertEquals(new BigDecimal(5), options.getRoundToNearest());
+		Assert.assertEquals(5, (int)options.getRoundToNearest());
 		Assert.assertEquals(item.getUuid(), options.getRoundingItemUuid());
 		Assert.assertEquals(true, options.isTimesheetRequired());
 	}

--- a/omod_1.x/src/main/java/org/openmrs/module/openhmis/cashier/web/controller/CashierOptionsController.java
+++ b/omod_1.x/src/main/java/org/openmrs/module/openhmis/cashier/web/controller/CashierOptionsController.java
@@ -58,7 +58,7 @@ public class CashierOptionsController {
 			// Check to see if rounding has been enabled and throw exception if it has as a rounding item must be set
 			if (StringUtils.isEmpty(roundingItemId) && options.getRoundToNearest() != null
 			        && !options.getRoundToNearest().equals(BigDecimal.ZERO)) {
-				throw new APIException("Rounding enabled (nearest " + options.getRoundToNearest().toPlainString()
+				throw new APIException("Rounding enabled (nearest " + options.getRoundToNearest().toString()
 				        + ") but no rounding item ID specified in options.");
 			}
 		}

--- a/omod_1.x/src/test/java/org/openmrs/module/openhmis/cashier/web/controller/CashierOptionsControllerTest.java
+++ b/omod_1.x/src/test/java/org/openmrs/module/openhmis/cashier/web/controller/CashierOptionsControllerTest.java
@@ -67,7 +67,7 @@ public class CashierOptionsControllerTest {
 		expectedEx.expect(APIException.class);
 		expectedEx.expectMessage("Rounding enabled ");
 		options = new CashierOptions();
-		options.setRoundToNearest(BigDecimal.TEN);
+		options.setRoundToNearest(10);
 		when(cashierOptionsService.getOptions()).thenReturn(options);
 		when(adminService.getGlobalProperty(ModuleSettings.ROUNDING_ITEM_ID)).thenReturn(null);
 		cashierOptionsController.options();


### PR DESCRIPTION
    Fixed the rounding design to be simpler and correct for bills with non-zero amounts
    Updated the CashierOptions.RoundToNearest to be an Integer
    Added additional rounding tests
    cash-250