### PR TITLE
Updated BillListItemResource to not search

### DIFF
--- a/omod_1.x/src/main/java/org/openmrs/module/webservices/rest/resource/BillLineItemResource.java
+++ b/omod_1.x/src/main/java/org/openmrs/module/webservices/rest/resource/BillLineItemResource.java
@@ -92,6 +92,11 @@ public class BillLineItemResource extends BaseRestDataResource<BillLineItem> {
 	}
 
 	@Override
+	public BillLineItem getByUniqueId(String uuid) {
+		return null;
+	}
+
+	@Override
 	public BillLineItem newDelegate() {
 		return new BillLineItem();
 	}


### PR DESCRIPTION
    The RESTWS Module 2.12+ now tries to load entities from the db when seeing a uuid field,
        this isn't supported for line items and resulted in an exception.
    ^cash-254 fixed